### PR TITLE
Update Readme to reflect new Klipper syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ For more information about Pressure Advance, see the Duet documentation: https:/
 
 Users of Klipper can add the following lines to their `printer.cfg`:
 ```
-[gcode_macro m900]
-default_parameter_K: 0
+[gcode_macro M900]
 gcode:
+  {% set K = params.K|default(0)|float %}
   SET_PRESSURE_ADVANCE ADVANCE={K}
 ```


### PR DESCRIPTION
Klipper received a breaking change on setting default parameters lately, so the macro needs to be updated.
https://github.com/Klipper3d/klipper/issues/4864